### PR TITLE
fix: reusable workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,12 +8,11 @@ permissions:
   contents: read
 
 jobs:
-
   unit-test:
-    uses: .github/workflows/unit-test.yaml
+    uses: ./.github/workflows/unit-test.yaml@main
 
   e2e-test:
-    uses: .github/workflows/e2e-test.yaml
+    uses: ./.github/workflows/e2e-test.yaml@main
 
   release:
     name: Release


### PR DESCRIPTION
## Description

The [release action](https://github.com/defenseunicorns/compliance-reporter/actions/workflows/release.yaml) has failed the last 8 times due to:

```bash
[Invalid workflow file: .github/workflows/release.yaml#L13](https://github.com/defenseunicorns/compliance-reporter/actions/runs/14333940192/workflow)
invalid value workflow reference: no version specified
```

It is due to the re-usable workflows. This should fix the release action so that it can find the correct workflows to run before the release

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Unit, [Journey](https://github.com/defenseunicorns/compliance-reporter/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/compliance-reporter/tree/main/e2e), [docs](https://github.com/defenseunicorns/compliance-reporter/tree/main/docs), [adr](https://github.com/defenseunicorns/compliance-reporter/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
