### PR TITLE
feat: add remarks to security controls

### DIFF
--- a/e2e/library.test.ts
+++ b/e2e/library.test.ts
@@ -10,21 +10,25 @@ describe("compliance-reporter", () => {
     SecurityContext: {
       id: "AC-1",
       description: "Prevents Pod Escalation",
+      remarks: "Some Remarks 1",
     },
 
     Storage: {
       id: "AC-2",
       description: "Prevents Volume Escalation",
+      remarks: "Some Remarks 2",
     },
 
     ServiceMesh: {
       id: "NIST-800-53-5",
       description: "Service Mesh",
+      remarks: "Some Remarks 3",
     },
 
     NetworkPolicy: {
       id: "NIST-800-53-6",
       description: "Network Policy",
+      remarks: "Some Remarks 4",
     },
   })
   const report = generateComplianceReport()
@@ -35,18 +39,22 @@ describe("compliance-reporter", () => {
       SecurityContext: {
         id: "AC-1",
         description: "Prevents Pod Escalation",
+        remarks: "Some Remarks 1",
       },
       Storage: {
         id: "AC-2",
         description: "Prevents Volume Escalation",
+        remarks: "Some Remarks 2",
       },
       ServiceMesh: {
         id: "NIST-800-53-5",
         description: "Service Mesh",
+        remarks: "Some Remarks 3",
       },
       NetworkPolicy: {
         id: "NIST-800-53-6",
         description: "Network Policy",
+        remarks: "Some Remarks 4",
       },
     })
   })
@@ -56,24 +64,28 @@ describe("compliance-reporter", () => {
       "AC-1": {
         id: "AC-1",
         description: "Prevents Pod Escalation",
+        remarks: "Some Remarks 1",
         coveragePercent: 0,
         implementations: [],
       },
       "AC-2": {
         id: "AC-2",
         description: "Prevents Volume Escalation",
+        remarks: "Some Remarks 2",
         coveragePercent: 0,
         implementations: [],
       },
       "NIST-800-53-5": {
         id: "NIST-800-53-5",
         description: "Service Mesh",
+        remarks: "Some Remarks 3",
         coveragePercent: 0,
         implementations: [],
       },
       "NIST-800-53-6": {
         id: "NIST-800-53-6",
         description: "Network Policy",
+        remarks: "Some Remarks 4",
         coveragePercent: 0,
         implementations: [],
       },
@@ -84,24 +96,28 @@ describe("compliance-reporter", () => {
       {
         id: "AC-1",
         description: "Prevents Pod Escalation",
+        remarks: "Some Remarks 1",
         coveragePercent: 0,
         implementations: [],
       },
       {
         id: "AC-2",
         description: "Prevents Volume Escalation",
+        remarks: "Some Remarks 2",
         coveragePercent: 0,
         implementations: [],
       },
       {
         id: "NIST-800-53-5",
         description: "Service Mesh",
+        remarks: "Some Remarks 3",
         coveragePercent: 0,
         implementations: [],
       },
       {
         id: "NIST-800-53-6",
         description: "Network Policy",
+        remarks: "Some Remarks 4",
         coveragePercent: 0,
         implementations: [],
       },

--- a/src/controls.test.ts
+++ b/src/controls.test.ts
@@ -27,10 +27,12 @@ describe("Controls Module", () => {
         SecurityContext: {
           id: "SC-1",
           description: "Security Context Control",
+          remarks: "Security Context Control remarks",
         },
         Storage: {
           id: "SC-2",
           description: "Storage Control",
+          remarks: "Storage Control remarks",
         },
       }
 
@@ -55,10 +57,12 @@ describe("Controls Module", () => {
         SecurityContext1: {
           id: "SC-1",
           description: "Security Context Control 1",
+          remarks: "Security Context Control remarks 1",
         },
         SecurityContext2: {
           id: "SC-1", // Duplicate ID
           description: "Security Context Control 2",
+          remarks: "Security Context Control remarks 2",
         },
       }
 
@@ -73,10 +77,12 @@ describe("Controls Module", () => {
       const control1 = {
         id: "SC-1",
         description: "Security Context Control",
+        remarks: "Security Context Control remarks",
       }
       const control2 = {
         id: "SC-1", // Same ID
         description: "Another Security Context Control",
+        remarks: "Another Security Context Control remarks",
       }
 
       // Act & Assert
@@ -91,6 +97,7 @@ describe("Controls Module", () => {
       const control = {
         id: "SC-1",
         description: "Security Context Control",
+        remarks: "Security Context Control remarks",
       }
 
       // Act
@@ -111,10 +118,12 @@ describe("Controls Module", () => {
         {
           id: "SC-1",
           description: "Security Context Control",
+          remarks: "Security Context Control remarks 1", 
         },
         {
           id: "SC-2",
           description: "Storage Control",
+          remarks: "Storage Control remarks 2",
         },
       ]
 
@@ -140,6 +149,7 @@ describe("Controls Module", () => {
       const control: Control = {
         id: "SC-1",
         description: "Security Context Control",
+        remarks: "Security Context Control remarks",
       }
       __test__.registeredControls.push(control)
 
@@ -161,6 +171,7 @@ describe("Controls Module", () => {
       const control: Control = {
         id: "SC-1",
         description: "Security Context Control",
+        remarks: "Security Context Control remarks",
       }
       __test__.registeredControls.push(control)
 
@@ -179,6 +190,7 @@ describe("Controls Module", () => {
       const control: Control = {
         id: "SC-1",
         description: "Security Context Control",
+        remarks: "Security Context Control remarks",
       }
       __test__.registeredControls.push(control)
 
@@ -195,6 +207,7 @@ describe("Controls Module", () => {
       const unregisteredControl: Control = {
         id: "UR-1",
         description: "Unregistered Control",
+        remarks: "Unregistered Control remarks",
       }
 
       // Act & Assert
@@ -209,6 +222,7 @@ describe("Controls Module", () => {
       const control: Control = {
         id: "SC-1",
         description: "Security Context Control",
+        remarks: "Security Context Control remarks",
       }
       __test__.registeredControls.push(control)
 
@@ -227,6 +241,7 @@ describe("Controls Module", () => {
       const control: Control = {
         id: "SC-1",
         description: "Security Context Control",
+        remarks: "Security Context Control remarks",
       }
       __test__.registeredControls.push(control)
 
@@ -244,6 +259,7 @@ describe("Controls Module", () => {
       const control: Control = {
         id: "SC-1",
         description: "Security Context Control",
+        remarks: "Security Context Control remarks",
       }
       __test__.registeredControls.push(control)
 
@@ -283,6 +299,7 @@ describe("Controls Module", () => {
       const control: Control = {
         id: "SC-1",
         description: "Security Context Control",
+        remarks: "Security Context Control remarks",
       }
       __test__.registeredControls.push(control)
 
@@ -312,10 +329,12 @@ describe("Controls Module", () => {
         {
           id: "SC-1",
           description: "Security Context Control",
+          remarks: "Security Context Control remarks",
         },
         {
           id: "NP-1",
           description: "Network Policy Control",
+          remarks: "Network Policy Control remarks",
         },
       )
 
@@ -333,6 +352,7 @@ describe("Controls Module", () => {
       __test__.registeredControls.push({
         id: "SC-1",
         description: "Security Context Control",
+        remarks: "Security Context Control remarks",
       })
 
       // Act
@@ -348,6 +368,7 @@ describe("Controls Module", () => {
       __test__.registeredControls.push({
         id: "SC-1",
         description: "Security Context Control",
+        remarks: "Security Context Control remarks",
         framework: "NIST",
         severity: "High",
       })
@@ -358,6 +379,7 @@ describe("Controls Module", () => {
       // Assert
       expect(report["SC-1"].id).toBe("SC-1")
       expect(report["SC-1"].description).toBe("Security Context Control")
+      expect(report["SC-1"].remarks).toBe("Security Context Control remarks")
       expect(report["SC-1"].framework).toBe("NIST")
       expect(report["SC-1"].severity).toBe("High")
     })
@@ -369,6 +391,7 @@ describe("Controls Module", () => {
       const control: Control = {
         id: "SC-1",
         description: "Security Context Control",
+        remarks: "Security Context Control remarks",
       }
       __test__.registeredControls.push(control)
 
@@ -392,14 +415,17 @@ describe("Controls Module", () => {
         {
           id: "SC-1",
           description: "Security Context Control",
+          remarks: "Security Context Control remarks",
         },
         {
           id: "NP-1",
           description: "Network Policy Control",
+          remarks: "Network Policy Control remarks",
         },
         {
           id: "PS-1",
           description: "Pod Security Control",
+          remarks: "Pod Security Control remarks",
         },
       )
 
@@ -434,6 +460,7 @@ describe("Controls Module", () => {
       __test__.registeredControls.push({
         id: "NP-1",
         description: "Network Policy Control",
+        remarks: "Network Policy Control remarks",
       })
 
       __test__.controlImplementations.push({

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -7,6 +7,7 @@ describe("Types Module", () => {
       const control: Control = {
         id: "TEST-1",
         description: "Test Control",
+        remarks: "Some remarks",
         framework: "Test Framework",
         severity: "High",
       }
@@ -14,6 +15,7 @@ describe("Types Module", () => {
       // Assert
       expect(control.id).toBe("TEST-1")
       expect(control.description).toBe("Test Control")
+      expect(control.remarks).toBe("Some remarks")
       expect(control.framework).toBe("Test Framework")
       expect(control.severity).toBe("High")
     })
@@ -24,10 +26,12 @@ describe("Types Module", () => {
       const control: Control = {
         id: "TEST-1",
         description: "Test Control",
+        remarks: "Some remarks"
       }
 
       expect(control.id).toBeDefined()
       expect(control.description).toBeDefined()
+      expect(control.remarks).toBeDefined()
     })
   })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,9 @@ export type Control = {
   /** Human-readable description of what this control addresses */
   description: string
 
+  /** Human-readable remarks about this control, (e.g., assessment objectives met by the control) */
+  remarks: string
+
   /** Optional fields for additional metadata */
   [key: string]: unknown
 }


### PR DESCRIPTION
## Description

This PR adds another field, `remarks`, to controls.

## Related Issue

Fixes #35

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Unit, [Journey](https://github.com/defenseunicorns/compliance-reporter/tree/main/journey), [E2E Tests](https://github.com/defenseunicorns/compliance-reporter/tree/main/e2e), [docs](https://github.com/defenseunicorns/compliance-reporter/tree/main/docs), [adr](https://github.com/defenseunicorns/compliance-reporter/tree/main/adr) added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
